### PR TITLE
clean up some logging and threading for VoiceProvider. 

### DIFF
--- a/Sources/Hume/API/EmpathicVoice/Client/StreamSocket.swift
+++ b/Sources/Hume/API/EmpathicVoice/Client/StreamSocket.swift
@@ -181,9 +181,10 @@ public class StreamSocket {
         do {
             try await webSocketTask.send(message)
         } catch {
-            Logger.error("Error sending message: \(error)\nClose code: \(String(describing: webSocketTask.closeCode))")
+            Logger.debug("Close code: \(String(describing: webSocketTask.closeCode))")
             switch webSocketTask.closeCode {
             case .invalid:
+                Logger.error("Socket connection error", error)
                 throw StreamSocketError.connectionError
                 
             case .goingAway:
@@ -193,6 +194,7 @@ public class StreamSocket {
                 throw StreamSocketError.closed
                 
             default:
+                Logger.error("Stream socket transport error", error)
                 throw StreamSocketError.transportError
             }
         }

--- a/Sources/Hume/Widget/Models/VoiceProviderError.swift
+++ b/Sources/Hume/Widget/Models/VoiceProviderError.swift
@@ -9,6 +9,8 @@ import Foundation
 
 /// Represents errors that can occur in the VoiceProvider lifecycle.
 public enum VoiceProviderError: Error {
+    /// VoiceProvider is either attempting to connect or disconnect
+    case connectionBusy
     /// The socket is not connected or was disconnected unexpectedly.
     case socketDisconnected
     /// Failed to initialize the microphone.

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
@@ -10,11 +10,13 @@ public class VoiceProvider: VoiceProvidable {
     
     private let humeClient: HumeClient
     private var socket: StreamSocket?
+    private let connectionQueue = DispatchQueue(label: "\(Constants.Namespace).connection.queue", qos: .userInteractive)
     private let delegateQueue = DispatchQueue(label: "\(Constants.Namespace).delegate.queue", qos: .userInteractive)
     private var eventSubscription: Task<(), any Error>?
     
     private var audioHub: AudioHub = AudioHubImpl()
     private var audioHubStateCancellable: AnyCancellable?
+    private let connectionLock = NSLock()
     
     public weak var delegate: (any VoiceProviderDelegate)?
 
@@ -51,17 +53,7 @@ public class VoiceProvider: VoiceProvidable {
     ///   - sessionSettings: Defines the session settings for the connection. Setting the `audio` configuration to `nil` will enable `VoiceProvider` to configure this automatically.
     public func connect(configId: String?, configVersion: String?, resumedChatGroupId: String?, sessionSettings: SessionSettings) async throws {
         Logger.info("Connecting voice provider. configId: \(String(describing: configId)), configVersion: \(String(describing: configVersion)), resumedChatGroupId: \(String(describing: resumedChatGroupId))")
-        if stateSubject.value == .disconnecting {
-            // need to wait to finish disconnecting
-            Logger.debug("was in the middle of disconnecting, waiting to finish...")
-            try await stateSubject.waitFor(.disconnected)
-            Logger.debug("...disconnected")
-        }
-        stateSubject.send(.connecting)
-        audioHub.microphoneDataChunkHandler = handleMicrophoneData(_:averagePower:)
-        if audioHub.stateSubject.value == .unconfigured {
-            try await audioHub.configure(with: .voiceChat)
-        }
+        
         
         var defaultedSessionSettings: SessionSettings? = nil
         if sessionSettings.audio == nil {
@@ -73,78 +65,124 @@ public class VoiceProvider: VoiceProvidable {
             )
         }
         
+        Logger.debug("acquiring connection lock")
+        guard self.connectionLock.try() else {
+            Logger.warn("Attempted connect while connection lock busy")
+            return
+        }
+        Logger.debug("acquired connection lock")
+        
         try await withCheckedThrowingContinuation { [defaultedSessionSettings] continuation in
-            // open socket
-            Task {
-                self.socket = try? await self.humeClient.empathicVoice.chat
-                    .connect(
-                        configId: configId,
-                        configVersion: configVersion,
-                        resumedChatGroupId: resumedChatGroupId,
-                        onOpen: { [weak self] response in
-                            Logger.info("Socket Opened")
-                            guard let self = self else { return }
-                            Task {
-                                do {
-                                    Logger.info("Voice provider listening for events")
-                                    self.startListeningForEvents()
-                                    try await self.sendSessionSettings(message: defaultedSessionSettings ?? sessionSettings)
-                                    
-                                    Logger.info("Waiting for audio hub to be ready")
-                                    try await self.audioHub.state.waitFor(.running)
-                                    
-                                    Logger.info("Finalizing audio hub configuration")
-                                    self.audioHub.isOutputMeteringEnabled = self.isOutputMeteringEnabled
-                                    self.audioHub.outputMeterListener = self.handleOutputMeter(_:)
-                                    self.stateSubject.send(.connected)
-                                    self.delegateQueue.async {
-                                        self.delegate?.voiceProviderDidConnect(self)
+            connectionQueue.async { [weak self] in
+                Task {
+                    guard let self else {
+                        Logger.error("lost self")
+                        return
+                    }
+                    
+                    Task { @MainActor in
+                        self.stateSubject.send(.connecting)
+                    }
+                    self.audioHub.microphoneDataChunkHandler = self.handleMicrophoneData(_:averagePower:)
+                    if self.audioHub.stateSubject.value == .unconfigured {
+                        try await self.audioHub.configure(with: .voiceChat)
+                    }
+                    
+                    self.socket = try? await self.humeClient.empathicVoice.chat
+                        .connect(
+                            configId: configId,
+                            configVersion: configVersion,
+                            resumedChatGroupId: resumedChatGroupId,
+                            onOpen: { [weak self] response in
+                                Logger.info("Socket Opened")
+                                guard let self = self else { return }
+                                Task {
+                                    do {
+                                        Logger.info("Voice provider listening for events")
+                                        self.startListeningForEvents()
+                                        try await self.sendSessionSettings(message: defaultedSessionSettings ?? sessionSettings)
+                                        
+                                        Logger.info("Waiting for audio hub to be ready")
+                                        try await self.audioHub.state.waitFor(.running)
+                                        
+                                        Logger.info("Finalizing audio hub configuration")
+                                        self.audioHub.isOutputMeteringEnabled = self.isOutputMeteringEnabled
+                                        self.audioHub.outputMeterListener = self.handleOutputMeter(_:)
+                                        self.stateSubject.send(.connected)
+                                        
+                                        Logger.debug("releasing connection lock")
+                                        self.connectionLock.unlock()
+                                        
+                                        self.delegateQueue.async {
+                                            self.delegate?.voiceProviderDidConnect(self)
+                                        }
+                                        continuation.resume()
+                                        Logger.info("Voice Provider connected successfully")
+                                    } catch {
+                                        continuation.resume(throwing: error)
+                                        Logger.debug("releasing connection lock")
+                                        self.connectionLock.unlock()
                                     }
-                                    continuation.resume()
-                                    Logger.info("Voice Provider connected successfully")
-                                } catch {
-                                    continuation.resume(throwing: error)
                                 }
+                            },
+                            onClose: { [weak self] closeCode, reason in
+                                Logger.warn("Socket Closed: \(closeCode). Reason: \(String(describing: reason))")
+                                if self?.stateSubject.value == .connected || self?.stateSubject.value == .connecting {
+                                    Task { await self?.disconnect() }
+                                }
+                            },
+                            onError: { error, response in
+                                Logger.warn("Socket Errored: \(error). Response: \(String(describing: response))")
                             }
-                        },
-                        onClose: { [weak self] closeCode, reason in
-                            Logger.warn("Socket Closed: \(closeCode). Reason: \(String(describing: reason))")
-                            if self?.stateSubject.value == .connected || self?.stateSubject.value == .connecting {
-                                Task { await self?.disconnect() }
-                            }
-                        },
-                        onError: { error, response in
-                            Logger.warn("Socket Errored: \(error). Response: \(String(describing: response))")
-                        }
-                    )
+                        )
+                }
             }
         }
     }
     
     public func disconnect() async {
-        Logger.info("attempting to disconnect voice provider")
-        guard [.connected, .connecting].contains(stateSubject.value) else {
-            Logger.info("not connected")
-            return
+        connectionQueue.async { [weak self] in
+            Task {
+                guard let self else {
+                    Logger.error("lost self")
+                    return
+                }
+                guard self.connectionLock.try() else {
+                    Logger.warn("Attempted disconnect while connection lock busy")
+                    return
+                }
+                Logger.debug("acquired connection lock")
+                defer {
+                    Logger.debug("releasing connection lock")
+                    self.connectionLock.unlock()
+                }
+                Logger.info("attempting to disconnect voice provider")
+                guard [.connected, .connecting].contains(self.stateSubject.value) else {
+                    Logger.info("not connected")
+                    return
+                }
+                await MainActor.run { self.stateSubject.send(.disconnecting) }
+                self.delegateQueue.async {
+                    self.delegate?.voiceProviderWillDisconnect(self)
+                }
+                Logger.info("Disconnecting voice provider")
+                
+                do {
+                    try await self.audioHub.stop()
+                } catch {
+                    Logger.error("Failed to stop audio hub: \(error)")
+                }
+                self.eventSubscription?.cancel()
+                self.socket?.close()
+                Logger.info("Voice provider disconnected")
+                self.delegateQueue.async {
+                    self.delegate?.voiceProviderDidDisconnect(self)
+                }
+                Task { @MainActor in
+                    self.stateSubject.send(.disconnected)
+                }
+            }
         }
-        await MainActor.run { stateSubject.send(.disconnecting) }
-        self.delegateQueue.async {
-            self.delegate?.voiceProviderWillDisconnect(self)
-        }
-        Logger.info("Disconnecting voice provider")
-        
-        do {
-            try await audioHub.stop()
-        } catch {
-            Logger.error("Failed to stop audio hub: \(error)")
-        }
-        eventSubscription?.cancel()
-        socket?.close()
-        Logger.info("Voice provider disconnected")
-        self.delegateQueue.async {
-            self.delegate?.voiceProviderDidDisconnect(self)
-        }
-        stateSubject.send(.disconnected)
     }
     
     // MARK: - Controls
@@ -199,7 +237,7 @@ extension VoiceProvider {
                             Logger.error("Error receiving messages: \(error). Disconnecting...")
                             Task { await self.disconnect() }
                         case .closed, .disconnected:
-                            Logger.debug("Event subscription received \(error.rawValue) code. Disconnecting...")
+                            Logger.debug("Event subscription received \(error.rawValue) code.")
                         case .encodingError, .decodingError:
                             Logger.warn("Event subscription received \(error.rawValue) code")
                         }
@@ -250,7 +288,12 @@ extension VoiceProvider {
                 try? await self.audioHub.start()
             }
         case .webSocketError(let error):
-            Logger.error("WebSocket error: \(error)")
+            if error.slug == "inactivity_timeout" {
+                Logger.warn("WebSocket error: \(error)")
+            } else {
+                Logger.error("WebSocket error: \(error)")
+            }
+            
             delegate?.voiceProvider(self, didProduceError: VoiceProviderError.websocketError(error))
             Task {
                 await self.disconnect()
@@ -275,11 +318,18 @@ extension VoiceProvider {
             }
             try await self.socket?.sendData(message: data)
         } catch let error as StreamSocketError {
-            // disconnect VoiceProvider
-            Logger.error("error sending mic data: \(error.rawValue)")
-            await self.disconnect()
-            delegateQueue.async {
-                self.delegate?.voiceProvider(self, didProduceError: VoiceProviderError.socketSendError(error))
+            // disconnect VoiceProvider if needed
+            switch error {
+            case .closed, .disconnected:
+                Logger.warn("received closed or disconnected error while sending mic data, cleaning up")
+                // if the socket is closed or disconnected while we're attempting to send mic data, it means AudioHub didn't
+                break
+            case .connectionError, .transportError, .encodingError, .decodingError:
+                Logger.error("error sending mic data: \(error.rawValue), disconnecting...")
+                delegateQueue.async {
+                    self.delegate?.voiceProvider(self, didProduceError: VoiceProviderError.socketSendError(error))
+                }
+                await self.disconnect()
             }
         } catch {
             Logger.error("error sending mic data: \(error)")


### PR DESCRIPTION
- Fixes bug where receiving a stream close/disconnect code occasionally puts us into an infinite loop of attempting to disconnect
- cleans up some logging
- locks/threading around managing `VoiceProvider` connection