### PR TITLE
Allow public soundplayer init

### DIFF
--- a/Sources/Hume/Widget/Audio/SoundPlayer.swift
+++ b/Sources/Hume/Widget/Audio/SoundPlayer.swift
@@ -21,7 +21,7 @@ public actor SoundPlayer: Sendable {
   private var meteringCallback: ((Float) -> Void)?
 
   // MARK: - Initialization
-  init(format: AVAudioFormat) {
+  public init(format: AVAudioFormat) {
     self.rawAudioPlayer = RawAudioPlayer(format: format)
   }
 

--- a/Sources/Hume/Widget/Audio/SoundPlayer.swift
+++ b/Sources/Hume/Widget/Audio/SoundPlayer.swift
@@ -10,7 +10,7 @@ public actor SoundPlayer: Sendable {
   // MARK: - Public Properties
   var format: AVAudioFormat { rawAudioPlayer.format }
 
-  var audioSourceNode: AVAudioSourceNode {
+  public var audioSourceNode: AVAudioSourceNode {
     rawAudioPlayer.meteredSourceNode.sourceNode
   }
 


### PR DESCRIPTION
My approach in the React Native example has been to do audio capture/playback in swift but manage the Websocket connection in Javascript. This means the React Native example cannot use VoiceProvider, but I've been trying to get it to use `AudioHub` and `SoundPlayer`.

Generally, this looks extremely straightforward for audio capture, but for audio playback it looks like I'm having to reproduce some of the logic in VoiceProvider that is private or too bespoke. https://github.com/HumeAI/hume-api-examples/pull/197/files#diff-322a06a11ec8ec6a43664041fc499ccb9b03cc1c0e0d3f03526fb7f06ecc7ee9R40

More specifically it looks like I can't initialize SoundPlayer outside VoiceProvider which I think I should be able to do. This just makes the constructor public.