### PR TITLE
expose unauthenticated error when socket connection fails. add tokenP…

### DIFF
--- a/Sources/Hume/Services/Networking/AccessTokenResolver.swift
+++ b/Sources/Hume/Services/Networking/AccessTokenResolver.swift
@@ -12,6 +12,8 @@ internal struct AccessTokenResolver {
     switch options {
     case .accessToken(let accessToken):
       return accessToken
+    case .accessTokenProvider(let tokenProvider):
+      return try await tokenProvider()
     }
   }
 }

--- a/Sources/Hume/Widget/Models/VoiceProviderError.swift
+++ b/Sources/Hume/Widget/Models/VoiceProviderError.swift
@@ -29,6 +29,8 @@ public enum VoiceProviderError: Error {
   case socketConnectionFailure(Error)
   /// Invalid session settings provided.
   case invalidSessionSettings
+  /// The chat connection received a `401` and may require a refreshed token.
+  case unauthorized
   /// An unknown error occurred.
   case unknown(Error)
 }


### PR DESCRIPTION
testing revealed a bad state in the consumer app where `VoiceProvider` got stuck in the `.connecting` state. It was due to a stale access token being used. This PR addresses this by:
- Adding a `tokenProvider` option to `HumeClient`, allowing the consumer to determine if the token needs a refresh before making a request
- Exposing an `.unauthenticated` error through the `VoiceProviderDelegate`