### PR TITLE
Support cross platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   name: "Hume",
   platforms: [
     .iOS(.v16),
-    .macOS(.v10_15),
+    .macOS(.v12),
   ],
   products: [
     // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -27,7 +27,10 @@ let package = Package(
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
     .target(
-      name: "Hume"),
+      name: "Hume",
+      swiftSettings: [
+        .define("HUME_WIDGET", .when(platforms: [.iOS]))
+      ]),
     .testTarget(
       name: "HumeTests",
       dependencies: ["Hume"]),

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Add to your `Package.swift`
     ]
 ```
 
+**Supported Platforms:** iOS 16+, macOS 12+, and Linux
+
 ## Usage
 
 The SDK provides a `VoiceProvider` abstraction that you can use to directly integrate
@@ -66,3 +68,27 @@ This way, you can install the same version each time without breaking changes.
 - Audio interruptions (e.g. phone calls) are not yet handled.
 - Manually starting/stopping `AVAudioSession` will likely break an active voice session.
 - Input metering is not yet implemented.
+
+## Build
+
+### Building for iOS
+```bash
+swift build --triple arm64-apple-ios --sdk $(xcrun --sdk iphoneos --show-sdk-path)
+```
+
+### Building for macOS
+```bash
+swift build --triple x86_64-apple-macosx --sdk $(xcrun --sdk macosx --show-sdk-path)
+```
+
+### Building for Linux
+```bash
+swift build
+```
+
+**Platform Support:**
+- **iOS**: Full functionality including Widget module (audio processing, microphone handling, TTS playback)
+- **macOS**: Core API functionality only (no Widget module)
+- **Linux**: Core API functionality only (no Widget module)
+
+**Note:** The Widget module is iOS-specific and contains audio processing, microphone handling, and TTS playback functionality. On macOS and Linux, only the core API functionality (HTTP clients, models, networking) is available.

--- a/Sources/Hume/Extensions/AVAdditions.swift
+++ b/Sources/Hume/Extensions/AVAdditions.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AVAdditions.swift
 //  HumeAI2
@@ -182,3 +183,4 @@ extension AVAudioEngine: Prettifiable {
       "\(type(of: node)) [Bus: \(point.bus), Channels: \(format.channelCount), SampleRate: \(format.sampleRate)]"
   }
 }
+#endif

--- a/Sources/Hume/Extensions/Data+Additions.swift
+++ b/Sources/Hume/Extensions/Data+Additions.swift
@@ -23,6 +23,7 @@ extension Data {
 }
 
 // MARK: - Audio Extensions
+#if HUME_WIDGET
 extension Data {
   func parseWAVHeader() -> WAVHeader? {
     guard count >= 44 else { return nil }
@@ -58,3 +59,4 @@ extension Data {
     return nil
   }
 }
+#endif

--- a/Sources/Hume/Util/Constants.swift
+++ b/Sources/Hume/Util/Constants.swift
@@ -13,7 +13,9 @@ enum Constants {
   static var SampleSize: Int = { Int(Self.SampleRate * Self.InputBufferDuration) }()
   static let InputBufferDuration = 0.02
 
+#if HUME_WIDGET
   static let DefaultAudioFormat = AudioFormat.PCM_16BIT
+#endif
   static let MinimumBufferSize = 128
   static let MaximumBufferSize = 4096
 

--- a/Sources/Hume/Widget/Audio/AudioBufferProcessor.swift
+++ b/Sources/Hume/Widget/Audio/AudioBufferProcessor.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioBufferProcessor.swift
 //  HumeAI2
@@ -39,3 +40,4 @@ class AudioBufferProcessor {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/AudioFormat.swift
+++ b/Sources/Hume/Widget/Audio/AudioFormat.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioFormat.swift
 //  Hume
@@ -28,3 +29,4 @@ public enum AudioFormat {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/AudioHub/AudioHub.swift
+++ b/Sources/Hume/Widget/Audio/AudioHub/AudioHub.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioHub.swift
 //  Hume
@@ -324,3 +325,4 @@ extension AudioHub {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/AudioHub/AudioHubError.swift
+++ b/Sources/Hume/Widget/Audio/AudioHub/AudioHubError.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioHubError.swift
 //  Hume
@@ -16,3 +17,4 @@ public enum AudioHubError: Error {
   case outputFormatError
   case microphoneUnavailable
 }
+#endif

--- a/Sources/Hume/Widget/Audio/AudioHub/AudioHubState.swift
+++ b/Sources/Hume/Widget/Audio/AudioHub/AudioHubState.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioHubState.swift
 //  Hume
@@ -15,3 +16,4 @@ public enum AudioHubState {
   case running
   case stopping
 }
+#endif

--- a/Sources/Hume/Widget/Audio/AudioHubConfiguration.swift
+++ b/Sources/Hume/Widget/Audio/AudioHubConfiguration.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioSessionConfiguration.swift
 //  HumeAI2
@@ -42,3 +43,4 @@ enum AudioHubConfiguration {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Microphone.swift
+++ b/Sources/Hume/Widget/Audio/Microphone.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 import AVFoundation
 
 public enum MicrophoneError: Error {
@@ -125,3 +126,4 @@ extension Microphone {
   }
 
 }
+#endif

--- a/Sources/Hume/Widget/Audio/MicrophoneMode.swift
+++ b/Sources/Hume/Widget/Audio/MicrophoneMode.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  MicrophoneMode.swift
 //  HumeAI2
@@ -35,3 +36,4 @@ extension AVCaptureDevice.MicrophoneMode {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Nodes/MeteredAudioSourceNode.swift
+++ b/Sources/Hume/Widget/Audio/Nodes/MeteredAudioSourceNode.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  MeteredAudioSourceNode.swift
 //  HumeAI
@@ -89,3 +90,4 @@ class MeteredAudioSourceNode {
     return (currentPeak, currentDecibels)
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Nodes/RawAudioPlayer.swift
+++ b/Sources/Hume/Widget/Audio/Nodes/RawAudioPlayer.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  File.swift
 //  Hume
@@ -222,3 +223,4 @@ final class RawAudioPlayer: Sendable {
     return combinedData
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Resampler.swift
+++ b/Sources/Hume/Widget/Audio/Resampler.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  Resampler.swift
 //  HumeAI2
@@ -242,3 +243,4 @@ extension Resampler {
     return int16Data
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Session/AVAudioSessionNotificationHandler.swift
+++ b/Sources/Hume/Widget/Audio/Session/AVAudioSessionNotificationHandler.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 import AVFAudio
 import Foundation
 
@@ -104,3 +105,4 @@ final class AudioSessionNotificationHandler {
     unregister()
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Session/AudioSession.swift
+++ b/Sources/Hume/Widget/Audio/Session/AudioSession.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 import AVFAudio
 import Combine
 import Foundation
@@ -236,3 +237,4 @@ extension AudioSession {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Session/AudioSessionError.swift
+++ b/Sources/Hume/Widget/Audio/Session/AudioSessionError.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioSessionError.swift
 //  Hume
@@ -26,3 +27,4 @@ public enum AudioSessionError: Error {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/Audio/Session/AudioSessionIO.swift
+++ b/Sources/Hume/Widget/Audio/Session/AudioSessionIO.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  AudioSessionIO.swift
 //  Hume
@@ -11,3 +12,4 @@ struct AudioSessionIO {
   var input: AVAudioSessionPortDescription
   var output: AVAudioSessionPortDescription
 }
+#endif

--- a/Sources/Hume/Widget/Audio/SoundPlayer.swift
+++ b/Sources/Hume/Widget/Audio/SoundPlayer.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  SoundPlayer.swift
 //
@@ -48,3 +49,4 @@ public actor SoundPlayer: Sendable {
     meteringCallback = callback
   }
 }
+#endif

--- a/Sources/Hume/Widget/Models/SoundClip.swift
+++ b/Sources/Hume/Widget/Models/SoundClip.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  SoundClip.swift
 //  HumeAI2
@@ -69,3 +70,4 @@ extension SoundClip {
       header: data.parseWAVHeader())
   }
 }
+#endif

--- a/Sources/Hume/Widget/Models/VoiceProviderError.swift
+++ b/Sources/Hume/Widget/Models/VoiceProviderError.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  VoiceProviderError.swift
 //  Hume
@@ -34,3 +35,4 @@ public enum VoiceProviderError: Error {
   /// An unknown error occurred.
   case unknown(Error)
 }
+#endif

--- a/Sources/Hume/Widget/Models/WAVHeader.swift
+++ b/Sources/Hume/Widget/Models/WAVHeader.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  WAVHeader.swift
 //  Hume
@@ -36,3 +37,4 @@ extension WAVHeader {
       interleaved: self.numChannels > 1)
   }
 }
+#endif

--- a/Sources/Hume/Widget/TTSPlayer.swift
+++ b/Sources/Hume/Widget/TTSPlayer.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  TTSProvider.swift
 //  Hume
@@ -128,3 +129,4 @@ public class TTSPlayer {
     return _pcmPlayer!
   }
 }
+#endif

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvidable.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvidable.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  VoiceProvidable.swift
 //  Hume
@@ -26,3 +27,4 @@ public protocol VoiceProvidable {
   /// - Parameter mute: Pass `true` to mute, `false` to unmute.
   func mute(_ mute: Bool)
 }
+#endif

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 import AVFoundation
 import Combine
 import Foundation
@@ -379,3 +380,4 @@ extension VoiceProvider {
     }
   }
 }
+#endif

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProviderDelegate.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProviderDelegate.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  VoiceProviderDelegate.swift
 //  Hume
@@ -46,3 +47,4 @@ extension VoiceProviderDelegate {
   public func voiceProviderDidConnect(_ voiceProvider: any VoiceProvidable) {}
   public func voiceProvider(_ voiceProvider: any VoiceProvidable, didPlayClip clip: SoundClip) {}
 }
+#endif

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProviderState.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProviderState.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  VoiceProviderState.swift
 //  Hume
@@ -13,3 +14,4 @@ public enum VoiceProviderState {
   case disconnecting
   case disconnected
 }
+#endif

--- a/Sources/HumeTestingUtils/Mocks/MockMicrophoneMode.swift
+++ b/Sources/HumeTestingUtils/Mocks/MockMicrophoneMode.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  MockMicrophoneMode.swift
 //  Hume
@@ -16,3 +17,4 @@ extension MicrophoneMode {
     return MicrophoneMode(preferredMode: preferredMode, activeMode: activeMode)
   }
 }
+#endif

--- a/Sources/HumeTestingUtils/Services/MockVoiceProvider.swift
+++ b/Sources/HumeTestingUtils/Services/MockVoiceProvider.swift
@@ -1,3 +1,4 @@
+#if HUME_WIDGET
 //
 //  MockVoiceProvider.swift
 //  HumeAI2
@@ -98,3 +99,4 @@ extension UserMessage {
     return try! JSONDecoder().decode(UserMessage.self, from: data)
   }
 }
+#endif


### PR DESCRIPTION
* Wrapped every file under `Widget/` in conditional compilation.
* Decided to support only macOS v12+ because a bunch of networking stuff doesn't support earlier MacOS.
Now `swift build --triple x86_64-apple-macosx --sdk $(xcrun --sdk macosx --show-sdk-path)` succeeds.