### PR TITLE
enforce single instance of VoiceProvider

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,10 @@ let package = Package(
       dependencies: ["Hume"]),
     .target(
       name: "HumeTestingUtils",
-      dependencies: ["Hume"]
+      dependencies: ["Hume"],
+      swiftSettings: [
+        .define("HUME_IOS", .when(platforms: [.iOS]))
+      ]
     ),
 
   ]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import Hume
 let token = try await myAccessTokenClient.fetchAccessToken()
 humeClient = HumeClient(options: .accessToken(token: token))
 
-let voiceProvider = VoiceProvider(client: humeClient)
+let voiceProvider = VoiceProviderFactory.getVoiceProvider(client: humeClient)
 voiceProvider.delegate = myDelegate
 
 // Request permission to record audio. Be sure to add `Privacy - Microphone Usage Description`

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
@@ -3,6 +3,9 @@
   import Combine
   import Foundation
 
+  /// VoiceProvider is responsible for managing a voice-based chat session with EVI. It handles coordinating
+  /// the microphone input, sending audio data to EVI, receiving audio output, and playing it back.
+  /// There should only be one instance of VoiceProvider; acquire an instance from `VoiceProviderFactory`.
   public class VoiceProvider: VoiceProvidable {
     public var state: AnyPublisher<VoiceProviderState, Never> {
       stateSubject.eraseToAnyPublisher()
@@ -39,7 +42,12 @@
 
     // MARK: Init/deinit
 
+    @available(*, deprecated, message: "Use VoiceProviderFactory to fetch a single instance")
     public init(client: HumeClient) {
+      self.humeClient = client
+    }
+
+    internal init(with client: HumeClient) {
       self.humeClient = client
     }
 
@@ -57,6 +65,11 @@
       with options: ChatConnectOptions?,
       sessionSettings: SessionSettings
     ) async throws {
+      assert(stateSubject.value != .connected, "Already connected, please disconnect first")
+      assert(
+        stateSubject.value != .connecting,
+        "Already connecting, wait for connection to finish or disconnect first")
+
       Logger.info(
         "Connecting voice provider. options: \(String(describing: options))"
       )

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProviderFactory.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProviderFactory.swift
@@ -1,0 +1,23 @@
+//
+//  VoiceProviderFactory.swift
+//  Hume
+//
+//  Created by Chris on 9/10/25.
+//
+
+import Foundation
+
+public class VoiceProviderFactory {
+  public static let shared = VoiceProviderFactory()
+
+  private static var voiceProvider: VoiceProvider?
+
+  /// Get a single instance of `VoiceProvider`. Subsequent calls will return the same instance.
+  public func getVoiceProvider(client: HumeClient) -> VoiceProvider {
+    if let existingProvider = Self.voiceProvider {
+      return existingProvider
+    }
+    Self.voiceProvider = VoiceProvider(with: client)
+    return Self.voiceProvider!
+  }
+}


### PR DESCRIPTION
this pr makes sure we only have a single connection open at a time by:
- vending a single instance of `VoiceProvider`
- asserting we're not in a connected state when trying to connect