### PR TITLE
add support for input metering

### DIFF
--- a/Sources/Hume/Widget/Audio/AudioBufferProcessor.swift
+++ b/Sources/Hume/Widget/Audio/AudioBufferProcessor.swift
@@ -10,13 +10,15 @@
   import Accelerate
 
   class AudioBufferProcessor {
-    static private let queue = DispatchQueue(
+    internal var meteringEnabled: Bool = false
+
+    private let queue = DispatchQueue(
       label: "\(Constants.Namespace).audioBufferProcessor", qos: .userInteractive)
 
-    static func process(
+    func process(
       buffer: AVAudioPCMBuffer, isMuted: Bool, handler: @escaping MicrophoneDataChunkBlock
     ) {
-      queue.async {
+      queue.async { [weak self] in
         Task {
           let bufferList = buffer.audioBufferList
           let audioBuffer = bufferList.pointee.mBuffers
@@ -29,7 +31,7 @@
 
           if !isMuted {
             // Optional: Calculate average power if needed
-            let avgPower: Float = 0.0
+            let avgPower: Float = self?.averagePower(buffer: buffer) ?? 0
             await handler(data, avgPower)
           } else {
             // Create a zero-filled array for simulated silence
@@ -39,5 +41,75 @@
         }
       }
     }
+
+    /// Computes average power (RMS amplitude in 0...1) across all channels in the buffer.
+    /// - Note: For signed PCM formats, samples are expected in [-1, 1] (Float32) or [-32768, 32767] (Int16).
+    func averagePower(buffer: AVAudioPCMBuffer) -> Float {
+      guard meteringEnabled else { return 0 }
+      let format = buffer.format
+      let channels = Int(format.channelCount)
+      let frames = Int(buffer.frameLength)
+      guard channels > 0, frames > 0 else { return 0 }
+
+      // Helper to clamp to 0...1
+      @inline(__always)
+      func clamp01(_ x: Float) -> Float { max(0, min(1, x)) }
+
+      switch format.commonFormat {
+      case .pcmFormatFloat32:
+        // Handle both non-interleaved and interleaved Float32
+        if let channelData = buffer.floatChannelData {
+          // Non-interleaved: channelData[ch] points to contiguous frames for that channel
+          var accum: Float = 0
+          for ch in 0..<channels {
+            let ptr = channelData[ch]
+            var rms: Float = 0
+            vDSP_rmsqv(ptr, 1, &rms, vDSP_Length(frames))
+            accum += rms * rms  // accumulate mean-square to combine later
+          }
+          // Average mean-square across channels, then sqrt
+          let meanSquare = accum / Float(channels)
+          let rmsAll = sqrtf(meanSquare)
+          return clamp01(rmsAll)
+        } else {
+          // Interleaved Float32: single buffer with channels interleaved
+          let audioBuffer = buffer.audioBufferList.pointee.mBuffers
+          guard let mData = audioBuffer.mData else { return 0 }
+          let sampleCount = Int(audioBuffer.mDataByteSize) / MemoryLayout<Float>.size
+          let ptr = mData.bindMemory(to: Float.self, capacity: sampleCount)
+
+          // Compute RMS across all samples directly
+          var rms: Float = 0
+          vDSP_rmsqv(ptr, 1, &rms, vDSP_Length(sampleCount))
+          return clamp01(rms)
+        }
+
+      case .pcmFormatInt16:
+        // Handle both non-interleaved and interleaved Int16
+        let audioBuffer = buffer.audioBufferList.pointee.mBuffers
+        guard let mData = audioBuffer.mData else { return 0 }
+        let sampleCount = Int(audioBuffer.mDataByteSize) / MemoryLayout<Int16>.size
+        let int16Ptr = mData.bindMemory(to: Int16.self, capacity: sampleCount)
+
+        // Convert to Float in [-1, 1] and compute RMS
+        var rms: Float = 0
+        // Scale factor to map Int16 [-32768, 32767] to [-1, 1]
+        let scale: Float = 1.0 / 32768.0
+        // vDSP has a convenience to compute RMS on integer with scaling: convert to Float then RMS
+        // Allocate a temporary buffer for conversion
+        var temp = [Float](repeating: 0, count: sampleCount)
+        vDSP.convertElements(
+          of: UnsafeBufferPointer(start: int16Ptr, count: sampleCount), to: &temp)
+        vDSP.multiply(scale, temp, result: &temp)  // normalize
+        vDSP_rmsqv(temp, 1, &rms, vDSP_Length(sampleCount))
+        let clamped = clamp01(rms)
+        return clamped
+
+      default:
+        // Unsupported formats fall back to 0
+        return 0
+      }
+    }
+
   }
 #endif

--- a/Sources/Hume/Widget/Audio/AudioHub/AudioHub.swift
+++ b/Sources/Hume/Widget/Audio/AudioHub/AudioHub.swift
@@ -24,7 +24,7 @@
 
     // MARK: Microphone
     public private(set) var isRecording: Bool = false
-    private var microphone: Microphone?
+    public var microphone: Microphone?
     private let microphoneQueue = DispatchQueue(label: "\(Constants.Namespace).microphone.queue")
     public var microphoneDataChunkHandler: MicrophoneDataChunkBlock?
 

--- a/Sources/Hume/Widget/Audio/Microphone.swift
+++ b/Sources/Hume/Widget/Audio/Microphone.swift
@@ -11,7 +11,7 @@
 
   public typealias MicrophoneDataChunkBlock = (Data, Float) async -> Void
 
-  internal final class Microphone: NSObject {
+  public final class Microphone: NSObject {
     private let micConfig: MicConfig
 
     private var audioEngine: AVAudioEngine
@@ -24,6 +24,15 @@
 
     var onChunk: MicrophoneDataChunkBlock = { _, _ in }
     var isMuted: Bool = false
+
+    public var meteringEnabled: Bool {
+      get {
+        audioBufferProcessor.meteringEnabled
+      }
+      set {
+        audioBufferProcessor.meteringEnabled = newValue
+      }
+    }
 
     init(
       audioEngine: AVAudioEngine, sampleRate: Double, sampleSize: Int,
@@ -83,7 +92,7 @@
           inputBufferList: audioBufferList, frameCount: frameCount)
 
         // Pass the converted data to the buffer processor
-        AudioBufferProcessor.process(buffer: outputBuffer, isMuted: isMuted, handler: onChunk)
+        audioBufferProcessor.process(buffer: outputBuffer, isMuted: isMuted, handler: onChunk)
       } catch {
         Logger.error("Resampling failed: \(error.localizedDescription)")
         return kAudioComponentErr_InvalidFormat

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvidable.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvidable.swift
@@ -13,6 +13,7 @@
     var state: AnyPublisher<VoiceProviderState, Never> { get }
     var delegate: VoiceProviderDelegate? { get set }
     var isOutputMeteringEnabled: Bool { get set }
+    var isInputMeteringEnabled: Bool { get set }
     var microphoneMode: MicrophoneMode { get }
 
     /// Connects the VoiceProvider to the backend and prepares audio streaming.

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
@@ -34,6 +34,14 @@
       }
     }
 
+    public var isInputMeteringEnabled: Bool = false {
+      didSet {
+        Task {
+          await audioHub.microphone?.meteringEnabled = isInputMeteringEnabled
+        }
+      }
+    }
+
     // MARK: - Microphone
 
     public var microphoneMode: MicrophoneMode {

--- a/Sources/HumeTestingUtils/Services/MockVoiceProvider.swift
+++ b/Sources/HumeTestingUtils/Services/MockVoiceProvider.swift
@@ -22,6 +22,7 @@
 
     weak public var delegate: VoiceProviderDelegate?
     public var isOutputMeteringEnabled: Bool = false
+    public var isInputMeteringEnabled: Bool = false
     private var isConnected: Bool = false
     private var mockEventsTask: Task<Void, Never>?
 


### PR DESCRIPTION
- makes `AudioHub.microphone` publicly accessible
- Adds `meteringEnabled` property to `Microphone` to toggle input metering. Meter values are received in the `onChunk` callback. Off by default.