### PR TITLE
make sure output node lazy accessor initializes the outputNode before preparing new engine

### DIFF
--- a/Sources/Hume/Widget/Audio/AudioHub/AudioHub.swift
+++ b/Sources/Hume/Widget/Audio/AudioHub/AudioHub.swift
@@ -239,14 +239,17 @@
           audioEngine.detach(node)
         }
 
+        // ensure hardware output paths are realized on the fresh engine before preparing
+        _ = newEngine.outputNode
+        _ = newEngine.mainMixerNode
+
         for (node, fmt) in outputNodes {
           newEngine.attach(node)
           newEngine.connect(node, to: newEngine.mainMixerNode, format: fmt)
         }
 
+        try newEngine.prepare()
         self.audioEngine = newEngine
-        try audioEngine.prepare()
-        //          try audioEngine.start()
       } catch {
         Logger.error("Failed to reset audio session: \(error)")
       }


### PR DESCRIPTION
This change ensures the `outputNode` on the new engine that is being created gets initialized before attempting to prepare it.  

**Crash**
Execution stopped when calling prepare on `audioEngine` after setting it to a new instance.
```
*** Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio', reason: 'required condition is false: inputNode != nullptr || outputNode != nullptr'
```