### PR TITLE
use actor and lock to ensure consistant transitions in voice provider state change

### DIFF
--- a/Sources/Hume/Util/AsyncLock.swift
+++ b/Sources/Hume/Util/AsyncLock.swift
@@ -1,0 +1,41 @@
+#if HUME_IOS
+  //
+  //  AsyncLock.swift
+  //  Hume
+  //
+  //  Created by Chris on 11/17/25.
+  //
+
+  import Foundation
+
+  actor AsyncLock {
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+      if !isLocked {
+        isLocked = true
+        return
+      }
+
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        waiters.append(continuation)
+      }
+    }
+
+    func release() {
+      if let next = waiters.first {
+        waiters.removeFirst()
+        next.resume()
+      } else {
+        isLocked = false
+      }
+    }
+
+    func withLock<T>(_ operation: () async throws -> T) async rethrows -> T {
+      await acquire()
+      defer { release() }
+      return try await operation()
+    }
+  }
+#endif

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProviderStateActor.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProviderStateActor.swift
@@ -1,0 +1,71 @@
+#if HUME_IOS
+  //
+  //  VoiceProviderStateActor.swift
+  //  Hume
+  //
+  //  Created by Chris on 11/17/25.
+  //
+
+  import Combine
+  import Foundation
+
+  public actor VoiceProviderStateActor {
+    private var state: VoiceProviderState = .disconnected {
+      didSet {
+        Task { await MainActor.run { [state] in stateSubject.send(state) } }
+      }
+    }
+    internal let stateSubject: CurrentValueSubject<VoiceProviderState, Never>
+
+    private var waiters: [VoiceProviderState: [CheckedContinuation<Void, Never>]] = [:]
+
+    public init() {
+      self.stateSubject = CurrentValueSubject<VoiceProviderState, Never>(state)
+    }
+
+    public func getState() -> VoiceProviderState {
+      state
+    }
+
+    public func transition(to newState: VoiceProviderState) {
+      Logger.debug("VoiceProvider transitioning from \(state) to \(newState)")
+      guard isValidTransition(from: state, to: newState) else {
+        assertionFailure("Invalid VoiceProvider state transition: \(state) → \(newState)")
+        return
+      }
+
+      state = newState
+
+      // Resume any waiters waiting for this state
+      if var continuations = waiters[newState] {
+        waiters[newState] = nil
+        for continuation in continuations {
+          continuation.resume()
+        }
+      }
+    }
+
+    public func waitUntil(_ target: VoiceProviderState) async {
+      if state == target { return }
+
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        waiters[target, default: []].append(continuation)
+      }
+    }
+
+    private func isValidTransition(from: VoiceProviderState, to: VoiceProviderState) -> Bool {
+      switch (from, to) {
+      case (.disconnected, .connecting),
+        (.connecting, .connected),
+        (.connecting, .disconnected),
+        (.connecting, .disconnecting),
+        (.connected, .disconnecting),
+        (.disconnecting, .disconnected):
+        return true
+
+      default:
+        return false
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
This PR updates how `state` is managed in `VoiceProvider`. We're now using an actor to keep state thread-safe and a lock to isolate critical sections

- related to HUME-16259