### PR TITLE
Expose VoiceProvider tool response helpers

### DIFF
--- a/Sources/Hume/API/EmpathicVoice/Client/StreamSocket.swift
+++ b/Sources/Hume/API/EmpathicVoice/Client/StreamSocket.swift
@@ -88,6 +88,14 @@ public class StreamSocket {
     try await send(message)
   }
 
+  /**
+     Send tool error message.
+     Tool errors must be sent as JSON text (not binary) for EVI to process them correctly.
+     */
+  public func sendToolError(message: ToolErrorMessage) async throws {
+    try await send(message)
+  }
+
   private func receiveSingleMessage() async throws -> SubscribeEvent {
     switch try await webSocketTask.receive() {
     case .data:

--- a/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
+++ b/Sources/Hume/Widget/VoiceProvider/VoiceProvider.swift
@@ -260,6 +260,44 @@
     public func sendResumeAssistantMessage(message: ResumeAssistantMessage) async throws {
       try await socket?.resumeAssistant(message: message)
     }
+
+    public func sendToolResponse(
+      toolCallId: String,
+      content: String,
+      customSessionId: String? = nil,
+      toolName: String? = nil,
+      toolType: ToolType? = nil
+    ) async throws {
+      let message = ToolResponseMessage(
+        content: content,
+        customSessionId: customSessionId,
+        toolCallId: toolCallId,
+        toolName: toolName,
+        toolType: toolType
+      )
+      try await socket?.sendToolResponse(message: message)
+    }
+
+    public func sendToolError(
+      toolCallId: String,
+      error: String,
+      code: String? = nil,
+      content: String? = nil,
+      customSessionId: String? = nil,
+      level: ErrorLevel? = nil,
+      toolType: ToolType? = nil
+    ) async throws {
+      let message = ToolErrorMessage(
+        code: code,
+        content: content,
+        customSessionId: customSessionId,
+        error: error,
+        level: level,
+        toolCallId: toolCallId,
+        toolType: toolType
+      )
+      try await socket?.sendToolError(message: message)
+    }
   }
 
   // MARK: - Event Handling


### PR DESCRIPTION
Adds public VoiceProvider helpers for sending custom tool responses and tool errors while keeping the underlying socket private.\n\nWhy:\n- VoiceProvider already owns the EVI websocket and audio stack.\n- SubscribeEvent exposes tool_call/tool_response/tool_error events to delegates.\n- StreamSocket already supports tool_response; this adds symmetric tool_error support and high-level VoiceProvider wrappers so apps using VoiceProvider can complete client-invoked custom tool flows without reimplementing microphone/audio handling.\n\nPatch scope:\n- Adds StreamSocket.sendToolError(message:).\n- Adds VoiceProvider.sendToolResponse(...).\n- Adds VoiceProvider.sendToolError(...).\n- No changes to microphone, playback, connection, auth, or session behavior.